### PR TITLE
add hover for icons

### DIFF
--- a/src/CSS/academics/main.css
+++ b/src/CSS/academics/main.css
@@ -1,34 +1,50 @@
-@import url('./csit.css');
+@import url("./csit.css");
 
-.fa-solid{
+.fa-solid {
   transition: all 0.2s;
 }
 
-.fa-server:hover{
+.fa-server:hover {
   color: rgba(33, 33, 241, 0.5);
 }
 
-.fa-robot:hover{
+.fa-robot:hover {
   color: rgba(253, 77, 253, 0.548);
 }
 
-.fa-bolt:hover{
+.fa-bolt:hover {
   color: rgba(255, 255, 0, 0.637);
 }
 
-.fa-helmet-safety:hover{
+.fa-helmet-safety:hover {
   color: rgba(252, 172, 24, 0.5);
 }
 
-.fa-wrench:hover{
+.fa-wrench:hover {
   color: rgba(16, 255, 156, 0.5);
 }
 
-.fa-bolt:hover{
+.fa-bolt:hover {
   color: rgba(255, 255, 0, 0.637);
 }
 
-.sem-container{
+.fa-cubes:hover {
+  color: rgb(22, 103, 174);
+}
+
+.fa-android:hover {
+  color: rgb(159, 192, 55);
+}
+
+.fa-code:hover {
+  color: rgb(0, 0, 0);
+}
+
+.fa-connectdevelop:hover {
+  /* fallback for old browsers */
+  color: rgb(218, 165, 32);
+}
+.sem-container {
   margin-top: 10em;
   position: absolute;
   right: 0;
@@ -38,11 +54,11 @@
   flex-direction: column;
 }
 
-.sem-container ul{
+.sem-container ul {
   display: flex;
 }
 
-.btn-sem{
+.btn-sem {
   padding: 20px;
   background: rgba(92, 92, 255, 0.5);
   border: 1px solid var(--blue);
@@ -53,16 +69,16 @@
   transition: all 0.2s;
 }
 
-.btn-sem:hover{
+.btn-sem:hover {
   background: rgba(92, 92, 255, 0.171);
   border: 1px solid var(--blue);
   color: black;
 }
 
-.syllabus-link{
+.syllabus-link {
   width: fit-content;
   margin: auto;
-  margin-top: 2em ;
+  margin-top: 2em;
   font-size: 1.1em !important;
   padding-bottom: 12px !important;
   border-bottom: 1px dashed var(--blue) !important;


### PR DESCRIPTION
This is a pull request for issue #8 Icon colors.

Hello again. I navigated to the src/CSS/academics/main.css file.
I added hover effects for each of the icons that didn't previously have them.

![icon-pr](https://user-images.githubusercontent.com/75108349/179365861-35507152-429e-4f0c-a490-6d1bc00d5396.PNG)
![icon-pr2](https://user-images.githubusercontent.com/75108349/179365864-10b349dc-0df1-474b-a25c-85b89d89319a.PNG)
![icon-pr3](https://user-images.githubusercontent.com/75108349/179365869-d24395d5-71c3-4809-b405-c1b6724dcfba.PNG)
![icon-pr4](https://user-images.githubusercontent.com/75108349/179365870-9edca6e4-9aba-4b39-8b3f-51a9704089d2.PNG)
